### PR TITLE
Fix md5 function under node.js

### DIFF
--- a/rtm.js
+++ b/rtm.js
@@ -61,7 +61,7 @@
 		this.md5 = (!this.isNode)
 			? md5
 			: function(string) {
-				return crypto.createHash('md5').update(string).digest("hex");
+				return crypto.createHash('md5').update(string, 'utf8').digest("hex");
 			}
 
 		var appKey = (appKey) ? appKey : '',


### PR DESCRIPTION
I got the error "code = 96 msg = Invalid signature", when I called `rtm.get` method with multibyte chars(e.g: Japanese Kanji chars).
