### PR TITLE
Fix typo on crypto declaration

### DIFF
--- a/rtm.js
+++ b/rtm.js
@@ -9,7 +9,7 @@
  *   md5 function on other platforms. I recommend this one:
  *   http://www.myersdaily.org/joseph/javascript/md5-text.html
  *
- *   Based on RTM PHP Library by Adam Magaña
+ *   Based on RTM PHP Library by Adam MagaÃ±a
  *   @see https://github.com/adammagana/rtm-php-library
  *
  *   License (The MIT License)
@@ -45,7 +45,7 @@
 	}
 }(this, (function () {
 	var exports = function (appKey, appSecret, permissions, format) {
-		var https, crypt;
+		var https, crypto;
 
 		this.authUrl = 'https://www.rememberthemilk.com/services/auth/';
 		this.baseUrl = 'https://api.rememberthemilk.com/services/rest/';


### PR DESCRIPTION
Hey,

I recently started to play with existing RTM software and found also your's rtm-js too.
Just noticed a small typo on crypto declaration and thought to make pull request (my first try).

Github shows also changes for one name (containing UTF-8 special character) and for new line at end of the file.
I did not do there changes. I just edited the crypto part on github web editor.

BR
Ilari