### PR TITLE
Add functionality of exclude format param from encoded url (for #10)

### DIFF
--- a/rtm.js
+++ b/rtm.js
@@ -89,13 +89,16 @@
 		 * @param signed    Boolean specfying whether or not the URL should be signed
 		 * @return          Returns the URL encoded string of parameters
 		 */
-		this.encodeUrlParams = function (params, signed) {
+		this.encodeUrlParams = function (params, signed, excludeFormat) {
 			var params = (params) ? params : {},
 				signed = (signed) ? signed : false,
+				excludeFormat = (excludeFormat) ? excludeFormat : false,
 				paramString = '',
 				count;
 
-			params.format = this.format;
+			if(!excludeFormat){
+				params.format = this.format;
+			}
 			params.api_key = this.appKey;
 
 			count = 0;
@@ -166,7 +169,7 @@
 				params.frob = frob;
 			}
 
-			url = this.authUrl + this.encodeUrlParams(params, true);
+			url = this.authUrl + this.encodeUrlParams(params, true, true);
 
 			return url;
 		};


### PR DESCRIPTION
Add functionality of excluding `format` param from encoded url to the function `encodeUrlParams`.
And I also modified function `getAuthUrl`, to address issue #10. (add call param for `encodeUrlParams`, to exclude `format` param from authentication url)

This seems to work fine in my environment. (Node.js 7.5.0, Ubuntu 16.04 LTS)
I mean I confirmed that my application passed RTM authentication with this library and my modification.